### PR TITLE
Fix Webpack Hot Reload error (issue #3):

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -21,7 +21,19 @@ window.store = store
 // bootstrap state
 store.dispatch(fetchMe());
 
-ReactDOM.render(
-  <App store={store} />,
-  document.getElementById('root')
-);
+// renderApp function for hot reloading
+const renderApp = App => {
+  const NextApp = require('./components/App').default;
+  ReactDOM.render(
+    <NextApp store={store} />,
+    document.getElementById('root')
+  );
+}
+
+// hot loading
+if (module.hot) {
+  module.hot.accept("./components/App", () => { renderApp(App) })
+}
+
+// initial render
+renderApp(App)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('dotenv').config()
+require('dotenv').config();
 var webpack = require('webpack');
 var path = require('path');
 
@@ -14,6 +14,7 @@ var config = {
   output: {
     path: BUILD_DIR,
     filename: 'app.js',
+    publicPath: `http://localhost:${process.env.WEBPACK_PORT}/`,
   },
   module: {
     loaders : [
@@ -30,7 +31,8 @@ var config = {
     ]
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NamedModulesPlugin()
   ],
 
   devServer: {


### PR DESCRIPTION
**Changes Made:**
- Update webpack configuration to specify output.publicPath with webpack port.
- Update index to allow for re-rendering application on hot-reload.

**Explanation:**
The current bug is caused by webpack trying to retrieve hot-update.json data from localhost:5000/hot-update.json instead of localhost:5001/hot-update.json. This is fixed by updating the webpack configuration with a output.publicPath variable with the correct port number, retrieved using dotenv. Additionally, module.hot.accept and a renderApp function are added to index.js to re-render the app when changes are detected.

See: https://medium.com/@dan_abramov/hot-reloading-in-react-1140438583bf

**Before:**
![image](https://user-images.githubusercontent.com/535932/47117293-f62a5500-d231-11e8-9e0b-fe5168f889f7.png)

_... make some changes to client code ..._

![image](https://user-images.githubusercontent.com/535932/47117302-fcb8cc80-d231-11e8-97b4-b8de340aa574.png)

**After:**
![image](https://user-images.githubusercontent.com/535932/47117308-03dfda80-d232-11e8-9f09-fe9cf6ecd923.png)

_... make some changes to client code ..._

![image](https://user-images.githubusercontent.com/535932/47117314-080bf800-d232-11e8-9854-05cb4c64d28d.png)